### PR TITLE
Feat: Include TukanStudios plugins to JSFX section.

### DIFF
--- a/README.md
+++ b/README.md
@@ -51,6 +51,7 @@ See [`CONTRIBUTING.md`](CONTRIBUTING.md) file for details on [Quality standards]
 
 - [geraintluff/jsfx](https://geraintluff.github.io/jsfx/) - Collection of JSFX effects by Geraint Luff (aka geraintluff). [Repo](https://github.com/geraintluff/jsfx), [Youtube playlist](https://www.youtube.com/watch?v=QLh6b88OvFs&list=PLflIiXZOocKqgKexrkTxxtl6igGUWnpXK), [forum thread](https://forums.cockos.com/showthread.php?t=186554).
 - [JoepVanlier/JSFX](https://github.com/JoepVanlier/JSFX) - A bundle of JSFX and scripts by Joep Vanlier (aka saike).
+- [TukanStudios/JSFX](https://stash.reaper.fm/v/43504/TUKANPLUGINS.png) - A bundle of JSFX by John Matthews (Tukan Studios). ([Repo](https://github.com/TukanStudios/TUKAN_STUDIOS_PLUGINS)) ([Youtube](https://www.youtube.com/@johnmatthews8435))
 
 ## Scripts
 


### PR DESCRIPTION
I've reached out to John of Tukan Studios and he has given permission to have his JSFX plugins included on this resource. Please consider this for inclusion.