### PR TITLE
Extensions: Add OSARA (Accessibility)

### DIFF
--- a/README.md
+++ b/README.md
@@ -73,6 +73,7 @@ See [`CONTRIBUTING.md`](CONTRIBUTING.md) file for details on [Quality standards]
 
 ### JSFX / EEL2 resources
 
+- [CodeBase](https://github.com/VisualCodeBase/CodeBase) - A multi in multi out modern compiler, which can convert JSFX to VST. [Forum thread](https://forum.cockos.com/showthread.php?t=245285).
 - [CookDSP](http://ajaxsoundstudio.com/cookdspdoc/) - DSP library for JSFX by Olivier Bélanger. [Repo](https://github.com/belangeo/cookdsp).
 - [JS2EEL](https://js2eel.org/) - A compiler that enables you to write REAPER JSFX in JavaScript by Daniel Schebesta. [Repo](https://github.com/steeelydan/js2eel). [Forum thread](https://forum.cockos.com/showthread.php?t=282257).
 
@@ -125,8 +126,6 @@ See [`CONTRIBUTING.md`](CONTRIBUTING.md) file for details on [Quality standards]
 - [Let's Talk About Reaper](https://www.youtube.com/channel/UCJjlFrOs2btJuErqrNu98Dg) - Myk Robinson's channel. Videos about Reaper, drums, guitar, home studio magic, and more.
 - [Reaper Mania](https://www.youtube.com/@REAPERMania) - The home of Kenny Gioia's Reaper Tutorials.
 - [The Reaper Blog](https://www.youtube.com/c/thereaperblog) - Jon Tidey's YouTube channel. Release news, tips, tricks and tutorials.
-- [Reapertips](https://www.youtube.com/@Reapertips) - Alejandro Hernandez's YouTube channel. Tips, tricks and tutorials.
-- [X-Raym's ReaScript Course](https://www.youtube.com/playlist?list=PL7M70tQL6s1IOYycGilaHLs5G4vOcyLF8) - Lua scripting for beginners.
 
 ## Community
 

--- a/README.md
+++ b/README.md
@@ -45,11 +45,11 @@ See [`CONTRIBUTING.md`](CONTRIBUTING.md) file for details on [Quality standards]
 - [Web sites](#web-sites)
 
 ## Extensions
-
-- [OSARA](https://osara.reaperaccessibility.com/) - REAPER extension which aims to make REAPER accessible to screen reader users. [Repo](https://github.com/jcsteh/osara).
+https://github.com/reaper-oss/sws
+- [OSARA](https://osara.reaperaccessibility.com/) - REAPER extension which aims to make REAPER accessible to screen reader users. A collaborative and open source project. [Repo](https://github.com/jcsteh/osara).
 - [ReaLlm](https://github.com/ak5k/reallm) - Low latency monitoring plug-in extension (automatically bypass plugins adding latency). [Forum thread](https://forum.cockos.com/showthread.php?t=245445).
-- [ReaPack](https://reapack.com/) - Package manager for Reaper. Discover, install and keep up to date your Reaper resources.
-- [SWS / S&M extension](https://www.sws-extension.org/) - A collection of features that seamlessly integrate into Reaper. A collaborative and open source project.
+- [ReaPack](https://reapack.com/) - Package manager for Reaper. Discover, install and keep up to date your Reaper resources. [Repo](https://github.com/cfillion/reapack), [Forum thread](https://forum.cockos.com/showthread.php?t=177978).
+- [SWS / S&M extension](https://www.sws-extension.org/) - A collection of features that seamlessly integrate into Reaper. A collaborative and open source project. [Repo](https://github.com/reaper-oss/sws), [Forum thread](https://forums.cockos.com/showthread.php?t=29640).
 
 ## JSFX
 

--- a/README.md
+++ b/README.md
@@ -74,7 +74,6 @@ See [`CONTRIBUTING.md`](CONTRIBUTING.md) file for details on [Quality standards]
 
 ### JSFX / EEL2 resources
 
-- [CodeBase](https://github.com/VisualCodeBase/CodeBase) - A multi in multi out modern compiler, which can convert JSFX to VST. [Forum thread](https://forum.cockos.com/showthread.php?t=245285).
 - [CookDSP](http://ajaxsoundstudio.com/cookdspdoc/) - DSP library for JSFX by Olivier Bélanger. [Repo](https://github.com/belangeo/cookdsp).
 - [JS2EEL](https://js2eel.org/) - A compiler that enables you to write REAPER JSFX in JavaScript by Daniel Schebesta. [Repo](https://github.com/steeelydan/js2eel). [Forum thread](https://forum.cockos.com/showthread.php?t=282257).
 

--- a/README.md
+++ b/README.md
@@ -74,6 +74,7 @@ See [`CONTRIBUTING.md`](CONTRIBUTING.md) file for details on [Quality standards]
 ### JSFX / EEL2 resources
 
 - [CookDSP](http://ajaxsoundstudio.com/cookdspdoc/) - DSP library for JSFX by Olivier Bélanger. [Repo](https://github.com/belangeo/cookdsp).
+- [JS2EEL](https://github.com/steeelydan/js2eel) - A compiler that enables you to write REAPER JSFX in JavaScript by Daniel Schebesta. [Forum thread](https://forum.cockos.com/showthread.php?t=282257).
 
 ### Lua resources
 

--- a/README.md
+++ b/README.md
@@ -74,7 +74,7 @@ See [`CONTRIBUTING.md`](CONTRIBUTING.md) file for details on [Quality standards]
 ### JSFX / EEL2 resources
 
 - [CookDSP](http://ajaxsoundstudio.com/cookdspdoc/) - DSP library for JSFX by Olivier Bélanger. [Repo](https://github.com/belangeo/cookdsp).
-- [JS2EEL](https://github.com/steeelydan/js2eel) - A compiler that enables you to write REAPER JSFX in JavaScript by Daniel Schebesta. [Forum thread](https://forum.cockos.com/showthread.php?t=282257).
+- [JS2EEL](https://js2eel.org/) - A compiler that enables you to write REAPER JSFX in JavaScript by Daniel Schebesta. [Repo]((https://github.com/steeelydan/js2eel)). [Forum thread](https://forum.cockos.com/showthread.php?t=282257).
 
 ### Lua resources
 

--- a/README.md
+++ b/README.md
@@ -125,7 +125,7 @@ See [`CONTRIBUTING.md`](CONTRIBUTING.md) file for details on [Quality standards]
 - [Let's Talk About Reaper](https://www.youtube.com/channel/UCJjlFrOs2btJuErqrNu98Dg) - Myk Robinson's channel. Videos about Reaper, drums, guitar, home studio magic, and more.
 - [Reaper Mania](https://www.youtube.com/@REAPERMania) - The home of Kenny Gioia's Reaper Tutorials.
 - [The Reaper Blog](https://www.youtube.com/c/thereaperblog) - Jon Tidey's YouTube channel. Release news, tips, tricks and tutorials.
-- [The Reaper Blog](https://www.youtube.com/@Reapertips) - Alejandro Hernandez's YouTube channel. Tips, tricks and tutorials.
+- [Reapertips](https://www.youtube.com/@Reapertips) - Alejandro Hernandez's YouTube channel. Tips, tricks and tutorials.
 - [X-Raym's ReaScript Course](https://www.youtube.com/playlist?list=PL7M70tQL6s1IOYycGilaHLs5G4vOcyLF8) - Lua scripting for beginners.
 
 ## Community

--- a/README.md
+++ b/README.md
@@ -74,7 +74,7 @@ See [`CONTRIBUTING.md`](CONTRIBUTING.md) file for details on [Quality standards]
 ### JSFX / EEL2 resources
 
 - [CookDSP](http://ajaxsoundstudio.com/cookdspdoc/) - DSP library for JSFX by Olivier Bélanger. [Repo](https://github.com/belangeo/cookdsp).
-- [JS2EEL](https://js2eel.org/) - A compiler that enables you to write REAPER JSFX in JavaScript by Daniel Schebesta. [Repo]((https://github.com/steeelydan/js2eel)). [Forum thread](https://forum.cockos.com/showthread.php?t=282257).
+- [JS2EEL](https://js2eel.org/) - A compiler that enables you to write REAPER JSFX in JavaScript by Daniel Schebesta. [Repo](https://github.com/steeelydan/js2eel). [Forum thread](https://forum.cockos.com/showthread.php?t=282257).
 
 ### Lua resources
 

--- a/README.md
+++ b/README.md
@@ -46,6 +46,7 @@ See [`CONTRIBUTING.md`](CONTRIBUTING.md) file for details on [Quality standards]
 
 ## Extensions
 
+- [OSARA](https://osara.reaperaccessibility.com/) - REAPER extension which aims to make REAPER accessible to screen reader users. [Repo](https://github.com/jcsteh/osara).
 - [ReaLlm](https://github.com/ak5k/reallm) - Low latency monitoring plug-in extension (automatically bypass plugins adding latency). [Forum thread](https://forum.cockos.com/showthread.php?t=245445).
 - [ReaPack](https://reapack.com/) - Package manager for Reaper. Discover, install and keep up to date your Reaper resources.
 - [SWS / S&M extension](https://www.sws-extension.org/) - A collection of features that seamlessly integrate into Reaper. A collaborative and open source project.

--- a/README.md
+++ b/README.md
@@ -125,6 +125,8 @@ See [`CONTRIBUTING.md`](CONTRIBUTING.md) file for details on [Quality standards]
 - [Let's Talk About Reaper](https://www.youtube.com/channel/UCJjlFrOs2btJuErqrNu98Dg) - Myk Robinson's channel. Videos about Reaper, drums, guitar, home studio magic, and more.
 - [Reaper Mania](https://www.youtube.com/@REAPERMania) - The home of Kenny Gioia's Reaper Tutorials.
 - [The Reaper Blog](https://www.youtube.com/c/thereaperblog) - Jon Tidey's YouTube channel. Release news, tips, tricks and tutorials.
+- [The Reaper Blog](https://www.youtube.com/@Reapertips) - Alejandro Hernandez's YouTube channel. Tips, tricks and tutorials.
+- [X-Raym's ReaScript Course](https://www.youtube.com/playlist?list=PL7M70tQL6s1IOYycGilaHLs5G4vOcyLF8) - Lua scripting for beginners.
 
 ## Community
 

--- a/README.md
+++ b/README.md
@@ -45,7 +45,7 @@ See [`CONTRIBUTING.md`](CONTRIBUTING.md) file for details on [Quality standards]
 - [Web sites](#web-sites)
 
 ## Extensions
-https://github.com/reaper-oss/sws
+
 - [OSARA](https://osara.reaperaccessibility.com/) - REAPER extension which aims to make REAPER accessible to screen reader users. A collaborative and open source project. [Repo](https://github.com/jcsteh/osara).
 - [ReaLlm](https://github.com/ak5k/reallm) - Low latency monitoring plug-in extension (automatically bypass plugins adding latency). [Forum thread](https://forum.cockos.com/showthread.php?t=245445).
 - [ReaPack](https://reapack.com/) - Package manager for Reaper. Discover, install and keep up to date your Reaper resources. [Repo](https://github.com/cfillion/reapack), [Forum thread](https://forum.cockos.com/showthread.php?t=177978).


### PR DESCRIPTION
Please add OSARA extension. Also, it might be a good idea to make an accessibility subcategory or wiki subcategory in order to list accessibility wiki. Or should I just add it to the web sites section?
https://reaperaccessibility.com/wiki/Main_Page