### PR TITLE
Software and tools: add ReaBoot; Documentation: add X-Raym's Reaper Action List website

### DIFF
--- a/README.md
+++ b/README.md
@@ -18,12 +18,13 @@ See [`CONTRIBUTING.md`](CONTRIBUTING.md) file for details on [Quality standards]
 # Contents
 
 - [Extensions](#extensions)
+- [Software and tools](#software-and-tools)
 - [JSFX](#jsfx)
 - [Scripts](#scripts)
 - [Video Editing](#video-editing)
 - [Scripting and JSFX development](#scripting-and-jsfx-development)
   - [General resources](#general-resources)
-  - [JSFX / EEL2 resources](#jsfx-eel2-resources)
+  - [JSFX / EEL2 resources](#jsfx--eel2-resources)
   - [Lua resources](#lua-resources)
   - [Python resources](#python-resources)
 - [Developer resources](#developer-resources)
@@ -49,6 +50,10 @@ See [`CONTRIBUTING.md`](CONTRIBUTING.md) file for details on [Quality standards]
 - [ReaLlm](https://github.com/ak5k/reallm) - Low latency monitoring plug-in extension (automatically bypass plugins adding latency). [Forum thread](https://forum.cockos.com/showthread.php?t=245445).
 - [ReaPack](https://reapack.com/) - Package manager for Reaper. Discover, install and keep up to date your Reaper resources.
 - [SWS / S&M extension](https://www.sws-extension.org/) - A collection of features that seamlessly integrate into Reaper. A collaborative and open source project.
+
+## Software and tools
+
+- [ReaBoot](https://reaboot.com/) - A convenient all-in-one online installer for REAPER, ReaPack and arbitrary packages by Helgoboss. [Repo](https://github.com/helgoboss/reaboot), [Forum thread](https://forums.cockos.com/showthread.php?p=2773571)
 
 ## JSFX
 
@@ -87,7 +92,8 @@ See [`CONTRIBUTING.md`](CONTRIBUTING.md) file for details on [Quality standards]
 - [JSFX API](https://www.reaper.fm/sdk/js/js.php) - The official JSFX API documentation.
 - [ReaImGui Documentation](https://api.codetabs.com/v1/proxy/?quest=https://github.com/cfillion/reaimgui/releases/latest/download/reaper_imgui_doc.html) - The official ReaImGui documentation.
 - [ReaScript API](https://www.reaper.fm/sdk/reascript/reascripthelp.html) - The official ReaScript API documentation.
-- [X-Raym Reascript API Documentation](https://www.extremraym.com/cloud/reascript-doc/) - Searchable and easy-to-read list of Reaper ReaScript API functions with common extensions support.
+- [X-Raym's Reaper Action List](https://www.extremraym.com/cloud/reaper-action-list/) - Interactive web page with the list of available Reaper actions, including internal and a selection of third-party ones. [Forum thread](https://forum.cockos.com/showthread.php?t=273727).
+- [X-Raym's Reascript API Documentation](https://www.extremraym.com/cloud/reascript-doc/) - Searchable and easy-to-read list of Reaper ReaScript API functions with common extensions support.
 
 #### General documentation and resources
 
@@ -145,9 +151,7 @@ See [`CONTRIBUTING.md`](CONTRIBUTING.md) file for details on [Quality standards]
 
 # Web sites
 
-- [ReaBoot](https://reaboot.com/) - ReaBoot is a convenient all-in-one online installer for REAPER, ReaPack and arbitrary packages. [Repo](https://github.com/helgoboss/reaboot), [Forum thread](https://forums.cockos.com/showthread.php?p=2773571)
 - [ReaLinks](https://www.realinks.net/) - Showcase of tools and stuffs created by user community. Curated by X-Raym.
-- [X-Raym's REAPER Action List Interactive Web Page](https://www.extremraym.com/cloud/reaper-action-list/) - Interactive web page where users can search existing actions, which is benefitial for both script developers and people who is searching for tools. [Forum thread](https://forum.cockos.com/showthread.php?t=273727).
 
 ---
 <!-- footnotes -->

--- a/README.md
+++ b/README.md
@@ -145,8 +145,9 @@ See [`CONTRIBUTING.md`](CONTRIBUTING.md) file for details on [Quality standards]
 
 # Web sites
 
-- [ReaBoot](https://reaboot.com/) - ReaBoot is a convenient all-in-one online installer for REAPER, ReaPack and arbitrary packages. [Repo](https://github.com/helgoboss/reaboot), [Forum](https://forums.cockos.com/showthread.php?p=2773571)
+- [ReaBoot](https://reaboot.com/) - ReaBoot is a convenient all-in-one online installer for REAPER, ReaPack and arbitrary packages. [Repo](https://github.com/helgoboss/reaboot), [Forum thread](https://forums.cockos.com/showthread.php?p=2773571)
 - [ReaLinks](https://www.realinks.net/) - Showcase of tools and stuffs created by user community. Curated by X-Raym.
+- [X-Raym's REAPER Action List Interactive Web Page](https://www.extremraym.com/cloud/reaper-action-list/) - Interactive web page where users can search existing actions, which is benefitial for both script developers and people who is searching for tools. [Forum thread](https://forum.cockos.com/showthread.php?t=273727).
 
 ---
 <!-- footnotes -->

--- a/README.md
+++ b/README.md
@@ -145,6 +145,7 @@ See [`CONTRIBUTING.md`](CONTRIBUTING.md) file for details on [Quality standards]
 
 # Web sites
 
+- [ReaBoot](https://reaboot.com/) - ReaBoot is a convenient all-in-one online installer for REAPER, ReaPack and arbitrary packages. [Repo](https://github.com/helgoboss/reaboot), [Forum](https://forums.cockos.com/showthread.php?p=2773571)
 - [ReaLinks](https://www.realinks.net/) - Showcase of tools and stuffs created by user community. Curated by X-Raym.
 
 ---


### PR DESCRIPTION
ReaBoot is a convenient all-in-one online installer for REAPER, ReaPack and arbitrary packages, and it's helpful for beginners.

X-Raym's REAPER Action List is convenient when searching existing ReaScripts as tools, ReaScript examples and to avoid reinventing the wheel.