### PR TITLE
Development tools: add ReaScript VSCode extension

### DIFF
--- a/README.md
+++ b/README.md
@@ -27,6 +27,7 @@ See [`CONTRIBUTING.md`](CONTRIBUTING.md) file for details on [Quality standards]
   - [Lua resources](#lua-resources)
   - [Python resources](#python-resources)
 - [Developer resources](#developer-resources)
+  - [Development tools](#development-tools)
   - [Documentation](#documentation)
     - [General documentation and resources](#general-documentation-and-resources)
   - [Libraries](#libraries)
@@ -70,9 +71,6 @@ See [`CONTRIBUTING.md`](CONTRIBUTING.md) file for details on [Quality standards]
 ### General resources
 
 - [ReaImGui](https://github.com/cfillion/reaimgui) - ReaImGui: ReaScript binding for Dear ImGui.
-- [ReaScript VS Code Extension](https://marketplace.visualstudio.com/items?itemName=AntoineBalaine.reascript-docs) - An extension for Reaper's ReaScript API methods in VS Code. [Forum thread](https://forum.cockos.com/showthread.php?t=247290), [Repo](https://github.com/AntoineBalaine/vscode-reascript-extension).
-- [Running scripts from VSCode guide](https://forum.cockos.com/showthread.php?t=266182) - A guide explaining the way to run ReaScripts from VSCode by Sexan.
-- [VSCode Snippet Builder](https://stash.reaper.fm/v/44422/VSCode%20Snippet%20Builder%20v0.13.zip) - Windows standalone app which creates a VSCode snippet file (for Lua only) from REAPER's 'reascripthelp.html' file by Edgemeal.
 
 ### JSFX / EEL2 resources
 
@@ -84,6 +82,9 @@ See [`CONTRIBUTING.md`](CONTRIBUTING.md) file for details on [Quality standards]
 ### Python resources
 
 ## Developer resources
+
+### Development tools
+- [ReaScript VSCode Extension](https://marketplace.visualstudio.com/items?itemName=AntoineBalaine.reascript-docs) - Reaper's ReaScript API methods in Visual Studio Code. [Forum thread](https://forum.cockos.com/showthread.php?t=247290), [Repo](https://github.com/AntoineBalaine/vscode-reascript-extension).
 
 ### Documentation
 

--- a/README.md
+++ b/README.md
@@ -71,6 +71,8 @@ See [`CONTRIBUTING.md`](CONTRIBUTING.md) file for details on [Quality standards]
 
 - [ReaImGui](https://github.com/cfillion/reaimgui) - ReaImGui: ReaScript binding for Dear ImGui.
 - [ReaScript VS Code Extension](https://marketplace.visualstudio.com/items?itemName=AntoineBalaine.reascript-docs) - An extension for Reaper's ReaScript API methods in VS Code. [Forum thread](https://forum.cockos.com/showthread.php?t=247290), [Repo](https://github.com/AntoineBalaine/vscode-reascript-extension).
+- [Runing scripts from VSCode guide](https://forum.cockos.com/showthread.php?t=266182) - A guide explaining the way to run ReaScripts from VSCode by Sexan.
+- [VSCode Snippet Builder](https://stash.reaper.fm/v/44422/VSCode%20Snippet%20Builder%20v0.13.zip) - Windows standalone app which creates a VSCode snippet file (for Lua only) from REAPER's 'reascripthelp.html' file by Edgemeal.
 
 ### JSFX / EEL2 resources
 

--- a/README.md
+++ b/README.md
@@ -70,6 +70,7 @@ See [`CONTRIBUTING.md`](CONTRIBUTING.md) file for details on [Quality standards]
 ### General resources
 
 - [ReaImGui](https://github.com/cfillion/reaimgui) - ReaImGui: ReaScript binding for Dear ImGui.
+- [ReaScript VS Code Extension](https://marketplace.visualstudio.com/items?itemName=AntoineBalaine.reascript-docs) - An extension for Reaper's ReaScript API methods in VS Code. [Forum thread](https://forum.cockos.com/showthread.php?t=247290), [Repo](https://github.com/AntoineBalaine/vscode-reascript-extension).
 
 ### JSFX / EEL2 resources
 

--- a/README.md
+++ b/README.md
@@ -71,7 +71,7 @@ See [`CONTRIBUTING.md`](CONTRIBUTING.md) file for details on [Quality standards]
 
 - [ReaImGui](https://github.com/cfillion/reaimgui) - ReaImGui: ReaScript binding for Dear ImGui.
 - [ReaScript VS Code Extension](https://marketplace.visualstudio.com/items?itemName=AntoineBalaine.reascript-docs) - An extension for Reaper's ReaScript API methods in VS Code. [Forum thread](https://forum.cockos.com/showthread.php?t=247290), [Repo](https://github.com/AntoineBalaine/vscode-reascript-extension).
-- [Runing scripts from VSCode guide](https://forum.cockos.com/showthread.php?t=266182) - A guide explaining the way to run ReaScripts from VSCode by Sexan.
+- [Running scripts from VSCode guide](https://forum.cockos.com/showthread.php?t=266182) - A guide explaining the way to run ReaScripts from VSCode by Sexan.
 - [VSCode Snippet Builder](https://stash.reaper.fm/v/44422/VSCode%20Snippet%20Builder%20v0.13.zip) - Windows standalone app which creates a VSCode snippet file (for Lua only) from REAPER's 'reascripthelp.html' file by Edgemeal.
 
 ### JSFX / EEL2 resources


### PR DESCRIPTION
It's a must have tool to do a ReaScript development in VS Code. Originally writen by gxray and currently maitained by Perken.

EDIT:
Also, Edgemeal's app and Sexan's guide is worth to list here.